### PR TITLE
Use current context tags for new doc

### DIFF
--- a/src/common/title.js
+++ b/src/common/title.js
@@ -3,7 +3,3 @@ export const DEFAULT_TITLE = "The App for Technical Writers"
 export const setTitle = (title) => {
   document.title = `${title ? title : DEFAULT_TITLE} | Octo`
 }
-
-export const formatTitleTags = (tags) => {
-  return tags.map(tag => `#${tag}`).join(", ")
-}

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -11,13 +11,17 @@ import { open } from '/src/router.js'
 import { firestoreInstance } from '/src/firebase.js'
 import { unpack } from '/src/models/doc.js'
 
-import { setTitle, formatTitleTags } from '/src/common/title.js'
+import { setTitle } from '/src/common/title.js'
 
 import {
   ADD_DOCUMENT,
   EDIT_DOCUMENT,
   SET_DOCUMENT,
 } from '/src/store/actions.js'
+
+const formatTags = (tags, delimiter = ", ") => {
+  return tags.map(tag => `#${tag}`).join(delimiter)
+}
 
 export default {
   name: 'EditorView',
@@ -56,7 +60,7 @@ export default {
   data() {
     return {
       editor: null,
-      placeholder: new Doc(),
+      placeholder: new Doc({ text: formatTags(this.$store.state.context.tags, " ") }),
     }
   },
   watch: {
@@ -96,7 +100,7 @@ export default {
   },
   methods: {
     async updateTitle() {
-      setTitle(this.document.headers[0] || formatTitleTags(this.document.tags))
+      setTitle(this.document.headers[0] || formatTags(this.document.tags))
     },
     async findSharedDocument() {
       const docRefs = await firestoreInstance


### PR DESCRIPTION
Resolves #84 

Use the current context tags as the base tags for a new document. Also
moves the tag formatting function into the Editor.vue file inline as it
has more utility than titles but no external use cases (yet).