### PR TITLE
Fix spooky mode not displaying graph correctly

### DIFF
--- a/src/components/Graph.vue
+++ b/src/components/Graph.vue
@@ -31,8 +31,8 @@ export default {
   computed: {
     colors() {
       return {
-        edge: this.theme === 'dark' ? '#333' : '#aaa',
-        label: this.theme === 'dark' ? 'rgba(200, 200, 200, 0.8)' : 'rgba(17, 17, 17, 0.8)',
+        edge: this.theme === 'light' ? '#aaa' : '#333',
+        label: this.theme === 'light' ? 'rgba(17, 17, 17, 0.8)' : 'rgba(200, 200, 200, 0.8)',
         node: 'rgba(224, 108, 117, 0.8)',
       }
     },


### PR DESCRIPTION
Resolves #157 

Simple fix to invert the logic given there is a single "light" mode.
Long term if more themes are added this code should likely be refactored
or themes tagged with some data indicating if they're `light` or `dark`.

**Spooky**
<img width="440" alt="image" src="https://user-images.githubusercontent.com/7366727/138602693-4cf29790-a0cc-4df7-bac3-6d35ac649174.png">

**Dark**
<img width="424" alt="image" src="https://user-images.githubusercontent.com/7366727/138602728-707d39a4-f9eb-4e70-89df-20328ad99b37.png">


**Light**
<img width="338" alt="image" src="https://user-images.githubusercontent.com/7366727/138602700-3ad55d24-c330-46de-9414-a9284bf49edb.png">

